### PR TITLE
prudebug: Add support for AM57x

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ to install the readline library. The binary is called prudebug.
 
 USAGE
 ---------------------------------------------------------------------
+```
 Usage: prudebug [-a pruss-address] [-u] [-m] [-p processor]
     -a - pruss-address is the memory address of the PRU in ARM memory space
     -u - force the use of UIO to map PRU memory space
@@ -77,6 +78,9 @@ Usage: prudebug [-a pruss-address] [-u] [-m] [-p processor]
     -p - select processor to use (sets the PRU memory locations)
         AM1707 - AM1707
         AM335X - AM335x
+        AM57X1 - AM57x1
+        AM57X2 - AM57x2
+```
 
 Generally the -a option should not be used.  If it is used, then prudebug will use the -a address for the PRU base with
 the selected processor as the various PRU subsystem offsets.  -u and -m control the way the PRU base address is mapped for

--- a/prudbg.c
+++ b/prudbg.c
@@ -1,4 +1,4 @@
-/* 
+/*
  *
  *  PRU Debug Program
  *  (c) Copyright 2011, 2013 by Arctica Technologies
@@ -92,6 +92,44 @@ struct pdb_tag {
 		.short_name 	= "AM335X",
 		.pruss_address 	= 0x4A300000,
 		.pruss_len 	= 0x40000,
+		.num_of_pruss	= 2,
+		.offsets	= {
+			{
+				.pruss_inst	= 0xD000,
+				.pruss_data	= 0x0000,
+				.pruss_ctrl	= 0x8800
+			},
+			{
+				.pruss_inst	= 0xE000,
+				.pruss_data	= 0x0800,
+				.pruss_ctrl	= 0x9000
+			}
+		}
+	},
+	{
+		.processor 	= "AM57x1",
+		.short_name 	= "AM57X1",
+		.pruss_address 	= 0x4b200000,
+		.pruss_len 	= 0x80000,
+		.num_of_pruss	= 2,
+		.offsets	= {
+			{
+				.pruss_inst	= 0xD000,
+				.pruss_data	= 0x0000,
+				.pruss_ctrl	= 0x8800
+			},
+			{
+				.pruss_inst	= 0xE000,
+				.pruss_data	= 0x0800,
+				.pruss_ctrl	= 0x9000
+			}
+		}
+	},
+	{
+		.processor 	= "AM57x2",
+		.short_name 	= "AM57X2",
+		.pruss_address 	= 0x4b280000,
+		.pruss_len 	= 0x80000,
 		.num_of_pruss	= 2,
 		.offsets	= {
 			{
@@ -696,4 +734,3 @@ int main(int argc, char *argv[])
 
 	return 0;
 }
-

--- a/prudbg.h
+++ b/prudbg.h
@@ -10,14 +10,15 @@
 #define PRUDBG_H
 
 // default processor to use if none is specified on the command line when prudebug is started
-#define DEFAULT_PROCESSOR_INDEX	AM335x
+#define DEFAULT_PROCESSOR_INDEX	AM57x1
 
 // list of processors to use in the define above (DEFAULT_PROCESSOR_INDEX)
 // value for define must match the array index in the processor structure
 // in the prudbg.c file.
 #define AM1707			0
 #define AM335x			1
-
+#define AM57x1			2
+#define AM57x2			3
 
 // general settings
 #define MAX_CMD_LEN		25

--- a/prudbg.h
+++ b/prudbg.h
@@ -10,7 +10,7 @@
 #define PRUDBG_H
 
 // default processor to use if none is specified on the command line when prudebug is started
-#define DEFAULT_PROCESSOR_INDEX	AM57x1
+#define DEFAULT_PROCESSOR_INDEX	AM335x
 
 // list of processors to use in the define above (DEFAULT_PROCESSOR_INDEX)
 // value for define must match the array index in the processor structure


### PR DESCRIPTION
- Tested the new jump instruction `j <num>` and the rest `ss`, `halt`, `r`, etc. are also all working fine.
- To view the program that I built and flashed please [click here](https://dhruvag2000.github.io/Blog-GSoC21/prudebug.html)

**New Features:**
- AM57x1: Support PRU 1 core 0 and 1
- AM57x2: Support PRU 2 core 0 and 1

**Changes:**
- modified:   README.md
  Add the 2 new options AM57x1 and 2

- modified:   prudbg.c
  Add AM57x1 and 2

- modified:   prudbg.h
  - Add #defines for AM57x1 and 2
  - Make AM57x1 as default